### PR TITLE
Integrate Alembic with env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python app/job/run.py
 
 ```bash
 alembic init alembic
-# 修改 alembic.ini 與 env.py 指向 app.core.database:Base
+# env.py 會從 `.env` 讀取 DATABASE_URL
 # 然後建立 migration
 alembic revision --autogenerate -m "init"
 alembic upgrade head

--- a/alembic.ini
+++ b/alembic.ini
@@ -84,7 +84,8 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = driver://user:pass@localhost/dbname
+# Database URL is loaded from .env by alembic/env.py
+# sqlalchemy.url =
 
 
 [post_write_hooks]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,13 +1,22 @@
 from logging.config import fileConfig
+import os
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
+from dotenv import load_dotenv
+
+from app.core.database import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+
+load_dotenv()
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
@@ -18,7 +27,7 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:


### PR DESCRIPTION
## Summary
- load `DATABASE_URL` from `.env` in Alembic
- keep connection string commented in `alembic.ini`
- document new migration step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688a16f79083298d624021a0939013