### PR TITLE
Fix README run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ docker-compose up -d
 ## 啟動 Kafka 消費者
 
 ```bash
-python3 app/mq/consumer.py
+python3 -m app.mq.consumer
 ```
 
 ## 執行 Job（可搭配 cron）
 
 ```bash
-python app/job/run.py
+python3 -m app.job.run
 ```
 
 ## Alembic 初始化


### PR DESCRIPTION
## Summary
- fix README instructions for running Kafka consumer and scheduled jobs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688b2518108329ac9af6d5b24d5f42