### PR TITLE
Add automated tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest httpx
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: pytest -q

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import pytest
+
+# Use in-memory SQLite by patching the database engine before app import
+import app.core.database as database
+database.engine = create_engine("sqlite:///:memory:")
+database.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=database.engine)
+database.Base.metadata.create_all(bind=database.engine)
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("/internal/v1/health/", {"status": "ok"}),
+        ("/mcm/v1/products/", {"product": "Sample product"}),
+        ("/scm/v1/orders/", {"orders": []}),
+    ],
+)
+def test_endpoints(url, expected):
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == expected

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -1,0 +1,25 @@
+import os
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Use SQLite to avoid requiring PostgreSQL
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+from app.models.order import Order
+from app.core.database import Base
+import app.services.order_service as order_service
+
+@pytest.fixture
+def test_session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(order_service, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+
+@pytest.mark.parametrize("name", ["Alice", "Bob"])
+def test_create_order(test_session, name):
+    order = order_service.create_order(name)
+    assert isinstance(order, Order)
+    assert order.customer_name == name


### PR DESCRIPTION
## Summary
- add pytest suite for API and order service
- configure GitHub Actions workflow to run tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dfe6a392c8329a5364a2880ac029c