### PR TITLE
Adjust API base path with base_router

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 DATABASE_URL=postgresql+psycopg2://postgres:password@localhost:5432/postgres
-ENV=dev
-APP_NAME=order_service  
+ENV=devAPP_NAME=order_service
+BASE_ROUTER=order_service
 OPENAI_API_KEY=

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,8 @@ from app.job import scheduler
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
-app.include_router(api_router)
+base_router = os.getenv("BASE_ROUTER", "")
+app.include_router(api_router, prefix=f"/{base_router}/api")
 
 if os.getenv("CRON_JOB", "false").lower() in {"1", "true", "yes"}:
     scheduler.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic
 confluent-kafka
 pydantic-settings
 apscheduler
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,9 +17,9 @@ client = TestClient(app)
 @pytest.mark.parametrize(
     "url,expected",
     [
-        ("/internal/v1/health/", {"status": "ok"}),
-        ("/mcm/v1/products/", {"product": "Sample product"}),
-        ("/scm/v1/orders/", {"orders": []}),
+        (f"/{os.getenv('BASE_ROUTER')}/api/internal/v1/health/", {"status": "ok"}),
+        (f"/{os.getenv('BASE_ROUTER')}/api/mcm/v1/products/", {"product": "Sample product"}),
+        (f"/{os.getenv('BASE_ROUTER')}/api/scm/v1/orders/", {"orders": []}),
     ],
 )
 def test_endpoints(url, expected):


### PR DESCRIPTION
## Summary
- rename router prefix variable to `base_router`
- set new env var `BASE_ROUTER` in `.env`
- update API tests for the renamed variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e029919a4832993b777b079283fe8