### PR TITLE
Add Codex review GitHub Action

### DIFF
--- a/.github/actions/codex-review-action/Dockerfile
+++ b/.github/actions/codex-review-action/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /action
+COPY requirements.txt /action/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py /action/
+ENTRYPOINT ["python", "/action/main.py"]

--- a/.github/actions/codex-review-action/action.yml
+++ b/.github/actions/codex-review-action/action.yml
@@ -1,0 +1,11 @@
+name: Codex Review Action
+description: "Use OpenAI Codex to review PR code changes"
+
+inputs:
+  openai_api_key:
+    description: "OpenAI API Key"
+    required: true
+
+runs:
+  using: "python"
+  main: "main.py"

--- a/.github/actions/codex-review-action/action.yml
+++ b/.github/actions/codex-review-action/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: "python"
-  main: "main.py"
+  using: "docker"
+  image: "Dockerfile"

--- a/.github/actions/codex-review-action/main.py
+++ b/.github/actions/codex-review-action/main.py
@@ -6,7 +6,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from github import Github
 import openai
-from app.core.logger import log_event
 
 REPO = os.getenv("GITHUB_REPOSITORY")
 PR_NUMBER = os.getenv("PR_NUMBER") or os.getenv("GITHUB_REF", "refs/pull/0").split("/")[-2]
@@ -43,14 +42,14 @@ def run_review(diff: str) -> str:
 
 
 def main() -> None:
-    log_event("CodexReview", "fetch_diff", {}, "INFO")
+    print("INFO: CodexReview - fetch_diff")
     diff = get_pr_diff()
-    log_event("CodexReview", "send_to_openai", {}, "INFO")
+    print("INFO: CodexReview - send_to_openai")
     result = run_review(diff)
-    log_event("CodexReview", "review_result", {"result": result}, "INFO")
+    print(f"INFO: CodexReview - review_result - {result}")
 
     if "\u91cd\u5927\u5b89\u5168\u554f\u984c" in result or "\u4e0d\u8981\u5408\u4f75" in result:
-        log_event("CodexReview", "critical_issue_found", {}, "ERROR")
+        print("ERROR: CodexReview - critical_issue_found")
         raise SystemExit(1)
 
 

--- a/.github/actions/codex-review-action/main.py
+++ b/.github/actions/codex-review-action/main.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+# Ensure repository root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from github import Github
+import openai
+from app.core.logger import log_event
+
+REPO = os.getenv("GITHUB_REPOSITORY")
+PR_NUMBER = os.getenv("PR_NUMBER") or os.getenv("GITHUB_REF", "refs/pull/0").split("/")[-2]
+TOKEN = os.getenv("GITHUB_TOKEN")
+API_KEY = os.getenv("INPUT_OPENAI_API_KEY")
+
+
+def get_pr_diff() -> str:
+    """Return aggregated diff text for the pull request."""
+    g = Github(TOKEN)
+    repo = g.get_repo(REPO)
+    pr = repo.get_pull(int(PR_NUMBER))
+    diff_text = ""
+    for file in pr.get_files():
+        if file.patch:
+            diff_text += f"\n--- {file.filename} ---\n{file.patch}\n"
+    return diff_text
+
+
+def run_review(diff: str) -> str:
+    """Submit diff to OpenAI and return the review."""
+    openai.api_key = API_KEY
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": "你是一位資安工程師，請審查這段 diff 內容是否有安全性或程式設計問題，並提出具體建議。請以繁體中文回答。",
+            },
+            {"role": "user", "content": diff[:4000]},
+        ],
+    )
+    return response["choices"][0]["message"]["content"]
+
+
+def main() -> None:
+    log_event("CodexReview", "fetch_diff", {}, "INFO")
+    diff = get_pr_diff()
+    log_event("CodexReview", "send_to_openai", {}, "INFO")
+    result = run_review(diff)
+    log_event("CodexReview", "review_result", {"result": result}, "INFO")
+
+    if "\u91cd\u5927\u5b89\u5168\u554f\u984c" in result or "\u4e0d\u8981\u5408\u4f75" in result:
+        log_event("CodexReview", "critical_issue_found", {}, "ERROR")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/codex-review-action/requirements.txt
+++ b/.github/actions/codex-review-action/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.0.0
+PyGithub
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,13 @@ jobs:
         env:
           PYTHONPATH: .
         run: pytest -q
+
+  codex-review:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run review with Codex
+        uses: ./.github/actions/codex-review-action
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,29 +4,20 @@ on:
   push:
   pull_request:
 
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest httpx
-      - name: Run tests
-        env:
-          PYTHONPATH: .
-        run: pytest -q
-
-  codex-review:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run review with Codex
-        uses: ./.github/actions/codex-review-action
-        with:
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt pytest httpx
+    - name: Run tests
+      env:
+        PYTHONPATH: .
+      run: pytest -q

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -5,15 +5,12 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
-  codex_review:
+  codex-review:
     runs-on: ubuntu-latest
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      INPUT_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-
+    needs: test
     steps:
     - uses: actions/checkout@v3
-
-    - name: Run Codex Review
-      uses: your-org/codex-review-action@v1
+    - name: Run review with Codex
+      uses: ./.github/actions/codex-review-action
+      with:
+        openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,19 @@
+name: Review
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  codex_review:
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INPUT_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Codex Review
+      uses: your-org/codex-review-action@v1


### PR DESCRIPTION
## Summary
- implement `codex-review-action` for OpenAI-driven PR reviews
- hook the new action into CI after tests pass
- use a Traditional Chinese system prompt for Codex review

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3751d8fc8329be518b731d6e3251