### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ pip3 install -r requirements.txt
 docker-compose up -d
 ```
 
+## Helm 部署
+
+若要在 Kubernetes 安裝此服務，可使用 `helm` 目錄下的 chart：
+
+```bash
+helm install microservice ./helm/microservice \
+  --set image.repository=myrepo/microservice
+```
+
+可透過 `values.yaml` 調整是否自動建立 PostgreSQL 與 Kafka。若 `postgres.enabled` 或
+`kafka.enabled` 設為 `false`，請另外填入 `postgres.url`、`postgres.user`、
+`postgres.password` 以及 `kafka.url` 等連線資訊，密碼將寫入 `Secret`。
+若啟用，兩者會以 StatefulSet 部署以保留資料。
+
 ## 啟動 FastAPI
 
 ```bash

--- a/helm/microservice/Chart.yaml
+++ b/helm/microservice/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: microservice
+version: 0.1.0
+appVersion: "1.0"
+description: A Helm chart for FastAPI microservice with scheduler

--- a/helm/microservice/templates/_helpers.tpl
+++ b/helm/microservice/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "microservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "microservice.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- $name = .Values.fullnameOverride -}}
+{{- end -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/microservice/templates/deployment-main.yaml
+++ b/helm/microservice/templates/deployment-main.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "microservice.fullname" . }}
+  labels:
+    app: {{ include "microservice.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "microservice.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "microservice.name" . }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python3", "-m", "uvicorn", "app.main:app", "--reload"]
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.postgres.url | quote }}
+            - name: KAFKA_URL
+              value: {{ .Values.kafka.url | quote }}
+            - name: KAFKA_USER
+              value: {{ .Values.kafka.user | quote }}
+            - name: CRON_JOB
+              value: "false"
+          envFrom:
+            - secretRef:
+                name: {{ include "microservice.fullname" . }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+

--- a/helm/microservice/templates/deployment-scheduler.yaml
+++ b/helm/microservice/templates/deployment-scheduler.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.scheduler.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "microservice.fullname" . }}-scheduler
+  labels:
+    app: {{ include "microservice.name" . }}-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "microservice.name" . }}-scheduler
+  template:
+    metadata:
+      labels:
+        app: {{ include "microservice.name" . }}-scheduler
+    spec:
+      containers:
+        - name: scheduler
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python3", "-m", "app.job.scheduler"]
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.postgres.url | quote }}
+            - name: KAFKA_URL
+              value: {{ .Values.kafka.url | quote }}
+            - name: KAFKA_USER
+              value: {{ .Values.kafka.user | quote }}
+            - name: CRON_JOB
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: {{ include "microservice.fullname" . }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}
+

--- a/helm/microservice/templates/hpa.yaml
+++ b/helm/microservice/templates/hpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "microservice.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "microservice.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.cpuUtilization }}
+{{- end }}
+

--- a/helm/microservice/templates/kafka-service.yaml
+++ b/helm/microservice/templates/kafka-service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kafka.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "microservice.fullname" . }}-kafka
+spec:
+  ports:
+    - port: 9092
+      targetPort: 9092
+  selector:
+    app: {{ include "microservice.name" . }}-kafka
+{{- end }}
+

--- a/helm/microservice/templates/kafka-statefulset.yaml
+++ b/helm/microservice/templates/kafka-statefulset.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.kafka.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "microservice.fullname" . }}-kafka
+spec:
+  serviceName: {{ include "microservice.fullname" . }}-kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "microservice.name" . }}-kafka
+  template:
+    metadata:
+      labels:
+        app: {{ include "microservice.name" . }}-kafka
+    spec:
+      containers:
+        - name: kafka
+          image: bitnami/kafka:3
+          env:
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: "localhost:2181"
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+          ports:
+            - containerPort: 9092
+{{- end }}
+

--- a/helm/microservice/templates/pdb.yaml
+++ b/helm/microservice/templates/pdb.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "microservice.fullname" . }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "microservice.name" . }}
+{{- end }}
+

--- a/helm/microservice/templates/postgres-service.yaml
+++ b/helm/microservice/templates/postgres-service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "microservice.fullname" . }}-postgres
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: {{ include "microservice.name" . }}-postgres
+{{- end }}
+

--- a/helm/microservice/templates/postgres-statefulset.yaml
+++ b/helm/microservice/templates/postgres-statefulset.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "microservice.fullname" . }}-postgres
+spec:
+  serviceName: {{ include "microservice.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "microservice.name" . }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ include "microservice.name" . }}-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "microservice.fullname" . }}
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+{{- end }}
+

--- a/helm/microservice/templates/secret.yaml
+++ b/helm/microservice/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "microservice.fullname" . }}
+  labels:
+    app: {{ include "microservice.name" . }}
+type: Opaque
+data:
+  POSTGRES_PASSWORD: {{ .Values.postgres.password | b64enc | quote }}
+  KAFKA_PASSWORD: {{ .Values.kafka.password | b64enc | quote }}
+

--- a/helm/microservice/templates/service.yaml
+++ b/helm/microservice/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "microservice.fullname" . }}
+  labels:
+    app: {{ include "microservice.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "microservice.name" . }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+

--- a/helm/microservice/values.yaml
+++ b/helm/microservice/values.yaml
@@ -1,0 +1,38 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: myrepo/microservice
+  tag: latest
+  pullPolicy: IfNotPresent
+
+scheduler:
+  enabled: true
+
+postgres:
+  enabled: false
+  url: "postgresql://postgres:5432/db"
+  user: postgres
+  password: ""
+
+kafka:
+  enabled: false
+  url: "kafka:9092"
+  user: ""
+  password: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  cpuUtilization: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1


### PR DESCRIPTION
## Summary
- add helm chart for the microservice with FastAPI and scheduler
- support optional creation of Postgres and Kafka
- include HPA and PDB templates
- document helm usage
- switch Postgres and Kafka to StatefulSet
- rename manifest files to match StatefulSet

## Testing
- `pytest -q`
- ❌ `helm version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3e4ef9b88329a92df12daa213266